### PR TITLE
feat: add inline choice conversion support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.0.1-SNAPSHOT"
+version = "0.1.0"
 
 plugins {
     // Apply the groovy plugin to also add support for Groovy (needed for Spock)

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/QtiToLearnosityConverterFactoryImpl.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/QtiToLearnosityConverterFactoryImpl.java
@@ -23,6 +23,7 @@ import com.epam.learnosity.converter.qti.core.converter.qti2p1.choice.ChoiceConv
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.AssessmentItem;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.Interaction;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.gapmatch.GapMatchConverter;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.inlinechoice.InlineChoiceConverter;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.match.MatchConverter;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.order.OrderConverter;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.textentry.TextEntryConverter;
@@ -41,6 +42,7 @@ public class QtiToLearnosityConverterFactoryImpl implements QtiToLearnosityConve
                 QtiType.MATCH, new MatchConverter(),
                 QtiType.CHOICE, new ChoiceConverter(),
                 QtiType.GAP_MATCH, new GapMatchConverter(),
+                QtiType.INLINE_CHOICE, new InlineChoiceConverter(),
                 QtiType.ORDER, new OrderConverter(),
                 QtiType.TEXT_ENTRY, new TextEntryConverter(),
                 QtiType.ASSOCIATE, new AssociateConverter()

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverter.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverter.java
@@ -28,7 +28,7 @@ import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.Respon
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.gapmatch.learnosity.ClozeAssociation;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.gapmatch.qti.GapMatchInteraction;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.gapmatch.qti.GapText;
-import com.epam.learnosity.converter.qti.core.converter.util.ResponseUtils;
+import com.epam.learnosity.converter.qti.core.converter.util.ValidationMappingUtils;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ public class GapMatchConverter extends QtiToLearnosityAbstractConverter<ClozeAss
         SequencedCollection<MapEntry> mapEntries = responseDeclaration.getMapping().getMapEntry();
 
         GapMatchInteraction gapMatchInteraction = (GapMatchInteraction) assessmentItem.getItemBody().getInteraction();
-        List<String> gapIds = ResponseUtils.extractElementIds(gapMatchInteraction.getTextBlock(), GAP_REGEX_PATTERN,
+        List<String> gapIds = ValidationMappingUtils.extractElementIds(gapMatchInteraction.getTextBlock(), GAP_REGEX_PATTERN,
                 RESPONSE_ID_REGEX_PATTERN);
 
         List<List<MapEntry>> gapMatchResponses = new ArrayList<>();
@@ -87,7 +87,7 @@ public class GapMatchConverter extends QtiToLearnosityAbstractConverter<ClozeAss
         }
 
         List<List<MapEntry>> cartesianProduct = Lists.cartesianProduct(gapMatchResponses);
-        List<StringValidResponse> validResponses = ResponseUtils.mapToStringResponses(cartesianProduct);
+        List<StringValidResponse> validResponses = ValidationMappingUtils.mapToStringResponses(cartesianProduct);
 
         List<StringValidResponse> sortedResponses = validResponses.stream()
                 .sorted(Comparator.comparing(stringValidResponse -> Double.parseDouble(stringValidResponse.getScore())))

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverter.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverter.java
@@ -1,0 +1,116 @@
+/*
+MIT License
+
+Copyright (c) 2025 EPAM Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.epam.learnosity.converter.qti.core.converter.qti2p1.inlinechoice;
+
+import com.epam.learnosity.converter.qti.core.converter.ConversionException;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.choice.learnosity.StringValidResponse;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.QtiToLearnosityAbstractConverter;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.learnosity.Validation;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.AssessmentItem;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.inlinechoice.learnosity.ClozeDropdown;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SequencedCollection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class InlineChoiceConverter extends QtiToLearnosityAbstractConverter<ClozeDropdown> {
+
+    private static final String MATCH_CORRECT_TEMPLATE = "http://www.imsglobal.org/question/qti_v2p1/rptemplates" +
+            "/match_correct";
+    private static final String INLINE_CHOICE_INTERACTION_PATTERN = "<inlineChoiceInteraction\\s+[^>]*>[\\s\\" +
+            "S]*?</inlineChoiceInteraction>";
+    private static final String INLINE_CHOICE_PATTERN = "<inlineChoice\\s+[^>]*>([^<]*)</inlineChoice>";
+    private static final String RESPONSE_IDENTIFIER_PATTERN = "responseIdentifier=\"([^\"]+)\"";
+    private static final String INLINE_CHOICE_VALUE_PATTERN_TEMPLATE = "<inlineChoice\\s+identifier=\"{0}\"[^>]*>" +
+            "([^<]+)</inlineChoice>";
+
+    @Override
+    public ClozeDropdown convert(AssessmentItem assessmentItem) {
+        if (!MATCH_CORRECT_TEMPLATE.equals(assessmentItem.getResponseProcessing().getTemplate())) {
+            throw new ConversionException("Unsupported response processing template. Please use match_correct");
+        }
+        ClozeDropdown clozeDropdown = new ClozeDropdown();
+        clozeDropdown.setTemplate(extractTemplate(assessmentItem));
+        clozeDropdown.setPossibleResponses(extractPossibleResponses(assessmentItem));
+        clozeDropdown.setShuffleOptions(isShuffleSet(assessmentItem));
+        clozeDropdown.setValidation(extractValidation(assessmentItem));
+        return clozeDropdown;
+    }
+
+    private boolean isShuffleSet(AssessmentItem assessmentItem) {
+        return assessmentItem.getItemBody().getContentAsSingleString().contains("shuffle=\"true\"");
+    }
+
+    private String extractTemplate(AssessmentItem assessmentItem) {
+        return assessmentItem.getItemBody().getContentAsSingleString()
+                .replaceAll(INLINE_CHOICE_INTERACTION_PATTERN, "{{response}}");
+    }
+
+    private List<List<String>> extractPossibleResponses(AssessmentItem assessmentItem) {
+        String content = assessmentItem.getItemBody().getContentAsSingleString();
+        Matcher inlineChoiceInteractionMatcher = Pattern.compile(INLINE_CHOICE_INTERACTION_PATTERN).matcher(content);
+        List<List<String>> possibleResponses = new ArrayList<>();
+        while (inlineChoiceInteractionMatcher.find()) {
+            String inlineChoiceInteraction = inlineChoiceInteractionMatcher.group(0);
+            Matcher inlineChoiceMatcher = Pattern.compile(INLINE_CHOICE_PATTERN).matcher(inlineChoiceInteraction);
+            List<String> inlineChoiceInteractionResponses = new ArrayList<>();
+            while (inlineChoiceMatcher.find()) {
+                inlineChoiceInteractionResponses.add(inlineChoiceMatcher.group(1));
+            }
+            possibleResponses.add(inlineChoiceInteractionResponses);
+        }
+        return possibleResponses;
+    }
+
+    private Validation extractValidation(AssessmentItem assessmentItem) {
+        var validation = new Validation();
+        validation.setScoringType(Validation.ScoringType.PARTIAL_MATCH_V2);
+        var validResponse = new StringValidResponse();
+        List<String> validResponses = extractValidResponses(assessmentItem);
+        validResponse.setScore(String.valueOf(validResponses.size()));
+        validResponse.setValue(validResponses);
+        validation.setValidResponse(validResponse);
+        return validation;
+    }
+
+    private static List<String> extractValidResponses(AssessmentItem assessmentItem) {
+        String content = assessmentItem.getItemBody().getContentAsSingleString();
+        Matcher responseIdMatcher = Pattern.compile(RESPONSE_IDENTIFIER_PATTERN).matcher(content);
+        List<String> validResponses = new ArrayList<>();
+        while (responseIdMatcher.find()) {
+            String responseId = responseIdMatcher.group(1);
+            SequencedCollection<String> correctResponseValues = assessmentItem.getResponseDeclaration().stream()
+                    .filter(responseDeclaration -> responseDeclaration.getIdentifier().equals(responseId))
+                    .map(responseDeclaration -> responseDeclaration.getCorrectResponse().getValue())
+                    .findFirst()
+                    .orElseThrow(() -> new ConversionException("Invalid XML encountered. No response declaration " +
+                            "available for the given responseId"));
+            // assuming there is only one correct response per inlineChoiceInteraction
+            String correctInlineChoiceValuePattern = MessageFormat.format(INLINE_CHOICE_VALUE_PATTERN_TEMPLATE,
+                    correctResponseValues.getFirst());
+            Matcher inlineChoiceValueMatcher = Pattern.compile(correctInlineChoiceValuePattern).matcher(content);
+            String correctResponseValue = inlineChoiceValueMatcher.find() ? inlineChoiceValueMatcher.group(1) : null;
+            validResponses.add(correctResponseValue);
+        }
+        return validResponses;
+    }
+}

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/learnosity/ClozeDropdown.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/learnosity/ClozeDropdown.java
@@ -16,28 +16,30 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-package com.epam.learnosity.converter.qti.core.converter.qti2p1.textentry.qti;
+package com.epam.learnosity.converter.qti.core.converter.qti2p1.inlinechoice.learnosity;
 
-import com.epam.learnosity.converter.qti.core.converter.qti2p1.QtiType;
-import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.Interaction;
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlRootElement;
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.learnosity.AbstractQuestionType;
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 /**
- * QTI 2.1 TextEntryInteraction element which requires blanks to be filled in a block of text.
+ * Learnosity's Cloze with dropdown (clozedropdown) element which requires students to select answers to text
+ * prompts from drop down menus.
  *
- * @see <a href="https://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10333">TextEntryInteraction</a>
+ * @see <a href="https://help.learnosity.com/hc/en-us/articles/22740756925469-Cloze-with-drop-down-clozedropdown">ClozeDropdown</a>
  */
 @Getter
 @Setter
-@XmlRootElement(namespace = "http://www.imsglobal.org/xsd/imsqti_v2p1")
-@XmlAccessorType(XmlAccessType.FIELD)
-public class TextEntryInteraction extends Interaction {
-    @Override
-    public QtiType getType() {
-        return QtiType.TEXT_ENTRY;
+public class ClozeDropdown extends AbstractQuestionType<String> {
+    private String template;
+
+    @SerializedName("possible_responses")
+    private List<List<String>> possibleResponses;
+
+    public ClozeDropdown() {
+        super("clozedropdown");
     }
 }

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverter.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverter.java
@@ -27,7 +27,7 @@ import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.Assess
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.MapEntry;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.qti.ResponseDeclaration;
 import com.epam.learnosity.converter.qti.core.converter.qti2p1.textentry.learnosity.ClozeText;
-import com.epam.learnosity.converter.qti.core.converter.util.ResponseUtils;
+import com.epam.learnosity.converter.qti.core.converter.util.ValidationMappingUtils;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,7 +60,7 @@ public class TextEntryConverter extends QtiToLearnosityAbstractConverter<ClozeTe
         validation.setScoringType(Validation.ScoringType.EXACT_MATCH);
         String content = assessmentItem.getItemBody().getContentAsSingleString();
 
-        List<String> responseIds = ResponseUtils.extractElementIds(content, TEXT_ENTRY_REGEX_PATTERN,
+        List<String> responseIds = ValidationMappingUtils.extractElementIds(content, TEXT_ENTRY_REGEX_PATTERN,
                 RESPONSE_ID_REGEX_PATTERN);
         List<ResponseDeclaration> responseDeclarations = assessmentItem.getResponseDeclaration();
         List<List<MapEntry>> interactionResponses = new ArrayList<>();
@@ -79,7 +79,7 @@ public class TextEntryConverter extends QtiToLearnosityAbstractConverter<ClozeTe
             }
         }
         List<List<MapEntry>> cartesianProduct = Lists.cartesianProduct(interactionResponses);
-        List<StringValidResponse> validResponses = ResponseUtils.mapToStringResponses(cartesianProduct);
+        List<StringValidResponse> validResponses = ValidationMappingUtils.mapToStringResponses(cartesianProduct);
 
         List<StringValidResponse> sortedResponses = validResponses.stream()
                 .sorted(Comparator.comparing(stringValidResponse -> Double.parseDouble(stringValidResponse.getScore())))

--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/util/ValidationMappingUtils.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/converter/util/ValidationMappingUtils.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @UtilityClass
-public class ResponseUtils {
+public class ValidationMappingUtils {
     /**
      * Extracts specified identifiers from a block of text by targeting specified elements
      *
@@ -42,9 +42,9 @@ public class ResponseUtils {
         Pattern elementRegexPattern = Pattern.compile(elementPattern);
         Matcher elementMatcher = elementRegexPattern.matcher(content);
         while (elementMatcher.find()) {
-            String gapMatchElement = elementMatcher.group(0);
+            String element = elementMatcher.group(0);
             Pattern responseIdPattern = Pattern.compile(idPattern);
-            Matcher responseIdMatcher = responseIdPattern.matcher(gapMatchElement);
+            Matcher responseIdMatcher = responseIdPattern.matcher(element);
             String id = responseIdMatcher.find() ? responseIdMatcher.group(1) : null;
             responseIds.add(id);
         }

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/AssessmentItemReaderTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/AssessmentItemReaderTest.groovy
@@ -220,13 +220,11 @@ class AssessmentItemReaderTest extends Specification {
         validResponses[1].getMappedValue() == "0.5"
 
         def itemBody = result.getItemBody()
-        itemBody.getContentAsSingleString() == "<p>Identify the missing word in this famous " +
-                "quote from Shakespeare's Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> " +
-                "Made glorious summer by this sun of\n" +
-                "\t\t\t\t\t<textEntryInteraction responseIdentifier=\"RESPONSE\" expectedLength=\"15\"/>;<br/>\n" +
-                "\t\t\t\tAnd all the clouds that lour'd upon our house<br/> In the deep bosom of the ocean\n" +
-                "\t\t\t\tburied.</p>\n" +
-                "\t\t</blockquote>"
+        itemBody.getContentAsSingleString() == "<p>Identify the missing word in this famous quote from Shakespeare's" +
+                " Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by " +
+                "this sun of\n                    <textEntryInteraction responseIdentifier=\"RESPONSE\" " +
+                "expectedLength=\"15\"/>;<br/>\n                And all the clouds that lour'd upon our house<br/>" +
+                " In the deep bosom of the ocean\n                buried.</p>\n        </blockquote>"
     }
 
     def readMultipleTextEntryTest() {
@@ -451,9 +449,10 @@ class AssessmentItemReaderTest extends Specification {
         interaction.getType() == QtiType.GAP_MATCH
         interaction.getResponseIdentifier() == "RESPONSE"
         interaction.getPrompt() == "Identify the missing words in this famous quote from Shakespeare's Richard III."
-        interaction.getTextBlock() == "<blockquote><p>Now is the <gap identifier=\"G1\"/> of our discontent<br/> Made" +
-                " glorious <gap identifier=\"G2\"/> by this sun of York;<br/> And all the clouds that lour'd\n" +
-                "\t\t\t\t\tupon our house<br/> In the deep bosom of the ocean buried.</p>\n\t\t\t</blockquote>"
+        interaction.getTextBlock() == "<blockquote><p>Now is the <gap identifier=\"G1\"/> of our discontent<br/> " +
+                "Made glorious <gap identifier=\"G2\"/> by this sun of York;<br/> And all the clouds that lour'd\n" +
+                "                    upon our house<br/> In the deep bosom of the ocean buried.</p>\n            " +
+                "</blockquote>"
         !interaction.isShuffle()
 
         def choices = interaction.getGapText()
@@ -464,5 +463,46 @@ class AssessmentItemReaderTest extends Specification {
                 new GapText("Su", 1, "summer"),
                 new GapText("A", 1, "autumn")
         )
+    }
+
+    def readInlineChoiceTest() {
+        given:
+        def qtiXml = getClass().getResource('/qti/inline_choice.xml').text
+        def reader = new AssessmentItemReader()
+
+        when:
+        def result = reader.read(qtiXml)
+
+        then:
+        result.getIdentifier() == "inlineChoice"
+        result.getTitle() == "Richard III (Take 2)"
+        !result.isAdaptive()
+        !result.isTimeDependent()
+        result.getResponseProcessing().getTemplate() == "http://www.imsglobal.org/question/qti_v2p1/rptemplates/" +
+                "match_correct"
+
+        def outcomeDeclaration = result.getOutcomeDeclaration()
+        outcomeDeclaration.getIdentifier() == "SCORE"
+        outcomeDeclaration.getCardinality() == "single"
+        outcomeDeclaration.getBaseType() == "float"
+
+        def responseDeclaration = result.getResponseDeclaration().getFirst()
+        responseDeclaration.getIdentifier() == "RESPONSE"
+        responseDeclaration.getCardinality() == "single"
+        responseDeclaration.getBaseType() == "identifier"
+        responseDeclaration.getMapping() == null
+
+        def validResponses = responseDeclaration.getCorrectResponse().getValue()
+        validResponses.size() == 1
+        validResponses[0] == "Y"
+
+        def itemBody = result.getItemBody()
+        itemBody.getContentAsSingleString() == "<p>Identify the missing word in this famous quote from Shakespeare's" +
+                " Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by" +
+                " this sun of\n                    <inlineChoiceInteraction responseIdentifier=\"RESPONSE\" " +
+                "shuffle=\"false\"><inlineChoice identifier=\"G\">Gloucester</inlineChoice><inlineChoice " +
+                "identifier=\"L\">Lancaster</inlineChoice><inlineChoice identifier=\"Y\">York</inlineChoice>\n" +
+                "                </inlineChoiceInteraction>;<br/> And all the clouds that lour'd upon our house" +
+                "<br/>\n                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
     }
 }

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverterTest.groovy
@@ -45,10 +45,9 @@ class GapMatchConverterTest extends Specification {
         !clozeAssociation.isInstantFeedback()
         !clozeAssociation.isShuffleOptions()
         !clozeAssociation.isDuplicateResponses()
-        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made" +
-                " glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n" +
-                "\t\t\t\t\tupon our house<br/> In the deep bosom of the ocean buried.</p>\n" +
-                "\t\t\t</blockquote>"
+        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made " +
+                "glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n             " +
+                "       upon our house<br/> In the deep bosom of the ocean buried.</p>\n            </blockquote>"
 
         def possibleResponses = clozeAssociation.getPossibleResponses()
         possibleResponses.size() == 4
@@ -88,10 +87,9 @@ class GapMatchConverterTest extends Specification {
         !clozeAssociation.isInstantFeedback()
         !clozeAssociation.isShuffleOptions()
         clozeAssociation.isDuplicateResponses()
-        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made" +
-                " glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n" +
-                "\t\t\t\t\tupon our house<br/> In the deep bosom of the ocean buried.</p>\n" +
-                "\t\t\t</blockquote>"
+        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made " +
+                "glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n             " +
+                "       upon our house<br/> In the deep bosom of the ocean buried.</p>\n            </blockquote>"
 
         def possibleResponses = clozeAssociation.getPossibleResponses()
         possibleResponses.size() == 4

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverterTest.groovy
@@ -1,0 +1,137 @@
+/*
+MIT License
+
+Copyright (c) 2025 EPAM Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.epam.learnosity.converter.qti.core.converter.qti2p1.inlinechoice
+
+import com.epam.learnosity.converter.qti.core.converter.ConversionException
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.AssessmentItemReader
+import com.epam.learnosity.converter.qti.core.converter.qti2p1.common.learnosity.Validation
+import spock.lang.Specification
+
+class InlineChoiceConverterTest extends Specification {
+    def convertSingleInlineChoiceTest() {
+        given:
+        def qtiXml = getClass().getResource('/qti/inline_choice.xml').text
+        def reader = new AssessmentItemReader()
+        def assessmentItem = reader.read(qtiXml)
+        def converter = new InlineChoiceConverter()
+
+        when:
+        def clozeDropdown = converter.convert(assessmentItem)
+
+        then:
+        clozeDropdown.getType() == "clozedropdown"
+        clozeDropdown.getMetadata() == null
+        clozeDropdown.getStimulus() == null
+        clozeDropdown.getStimulusReview() == null
+        clozeDropdown.getInstructorStimulus() == null
+        clozeDropdown.getFeedbackAttempts() == 0
+        !clozeDropdown.instantFeedback
+        !clozeDropdown.isShuffleOptions()
+        clozeDropdown.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's Richard" +
+                " III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by this sun" +
+                " of\n                    {{response}};<br/> And all the clouds that lour'd upon our house<br/>\n" +
+                "                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
+
+        def possibleResponses = clozeDropdown.getPossibleResponses()
+        possibleResponses.size() == 1
+
+        def firstInteractionResponses = possibleResponses.getFirst()
+        firstInteractionResponses.size() == 3
+        firstInteractionResponses[0] == "Gloucester"
+        firstInteractionResponses[1] == "Lancaster"
+        firstInteractionResponses[2] == "York"
+
+        def validation = clozeDropdown.getValidation()
+        validation.getScoringType() == Validation.ScoringType.PARTIAL_MATCH_V2
+        validation.getAltResponses() == null
+
+        def validResponse = validation.getValidResponse()
+        validResponse.score == "1"
+
+        def validResponseValues = validResponse.value
+        validResponseValues.size() == 1
+        validResponseValues[0] == "York"
+    }
+
+    def convertMultipleInlineChoiceTest() {
+        given:
+        def qtiXml = getClass().getResource('/qti/inline_choice_multiple_choices.xml').text
+        def reader = new AssessmentItemReader()
+        def assessmentItem = reader.read(qtiXml)
+        def converter = new InlineChoiceConverter()
+
+        when:
+        def clozeDropdown = converter.convert(assessmentItem)
+
+        then:
+        clozeDropdown.getType() == "clozedropdown"
+        clozeDropdown.getMetadata() == null
+        clozeDropdown.getStimulus() == null
+        clozeDropdown.getStimulusReview() == null
+        clozeDropdown.getInstructorStimulus() == null
+        clozeDropdown.getFeedbackAttempts() == 0
+        !clozeDropdown.instantFeedback
+        clozeDropdown.isShuffleOptions()
+        clozeDropdown.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's " +
+                "Richard III.</p><blockquote><p>{{response}} is the winter of our discontent<br/> Made glorious" +
+                " summer by this sun of\n                    {{response}};<br/> And all the clouds that lour'd upon" +
+                " our house<br/>\n                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
+
+        def possibleResponses = clozeDropdown.getPossibleResponses()
+        possibleResponses.size() == 2
+
+        def firstInteractionResponses = possibleResponses.getFirst()
+        firstInteractionResponses.size() == 2
+        firstInteractionResponses[0] == "Now"
+        firstInteractionResponses[1] == "Then"
+
+        def secondInteractionResponses = possibleResponses.getLast()
+        secondInteractionResponses.size() == 3
+        secondInteractionResponses.size() == 3
+        secondInteractionResponses[0] == "Gloucester"
+        secondInteractionResponses[1] == "Lancaster"
+        secondInteractionResponses[2] == "York"
+
+        def validation = clozeDropdown.getValidation()
+        validation.getScoringType() == Validation.ScoringType.PARTIAL_MATCH_V2
+        validation.getAltResponses() == null
+
+        def validResponse = validation.getValidResponse()
+        validResponse.score == "2"
+
+        def validResponseValues = validResponse.value
+        validResponseValues.size() == 2
+        validResponseValues[0] == "Now"
+        validResponseValues[1] == "York"
+    }
+
+    def convertInlineChoiceWithUnsupportedResponseProcessingTest() {
+        given:
+        def qtiXml = getClass().getResource('/qti/inline_choice_custom_processing.xml').text
+        def reader = new AssessmentItemReader()
+        def assessmentItem = reader.read(qtiXml)
+        def converter = new InlineChoiceConverter()
+
+        when:
+        converter.convert(assessmentItem)
+
+        then:
+        thrown ConversionException
+    }
+}

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverterTest.groovy
@@ -45,9 +45,9 @@ class TextEntryConverterTest extends Specification {
         !clozeText.isShuffleOptions()
         !clozeText.isCaseSensitive()
         clozeText.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's Richard " +
-                "III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by this sun " +
-                "of\n\t\t\t\t\t{{response}};<br/>\n\t\t\t\tAnd all the clouds that lour'd upon our house<br/> In the " +
-                "deep bosom of the ocean\n\t\t\t\tburied.</p>\n\t\t</blockquote>"
+                "III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by this sun" +
+                " of\n                    {{response}};<br/>\n                And all the clouds that lour'd upon" +
+                " our house<br/> In the deep bosom of the ocean\n                buried.</p>\n        </blockquote>"
 
         def validation = clozeText.getValidation()
         validation.getScoringType() == Validation.ScoringType.EXACT_MATCH

--- a/app/src/test/resources/qti/gap_match.xml
+++ b/app/src/test/resources/qti/gap_match.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
-	identifier="gapMatch" title="Richard III (Take 1)" adaptive="false" timeDependent="false">
-	<responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
-		<correctResponse>
-			<value>W G1</value>
-			<value>Su G2</value>
-		</correctResponse>
-		<mapping defaultValue="-1" lowerBound="0">
-			<mapEntry mapKey="W G1" mappedValue="1"/>
-			<mapEntry mapKey="Su G2" mappedValue="2"/>
-		</mapping>
-	</responseDeclaration>
-	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
-	<itemBody>
-		<gapMatchInteraction responseIdentifier="RESPONSE" shuffle="false">
-			<prompt>Identify the missing words in this famous quote from Shakespeare's Richard III.</prompt>
-			<gapText identifier="W" matchMax="1">winter</gapText>
-			<gapText identifier="Sp" matchMax="1">spring</gapText>
-			<gapText identifier="Su" matchMax="1">summer</gapText>
-			<gapText identifier="A" matchMax="1">autumn</gapText>
-			<blockquote>
-				<p>Now is the <gap identifier="G1"/> of our discontent<br/> Made glorious <gap
-						identifier="G2"/> by this sun of York;<br/> And all the clouds that lour'd
-					upon our house<br/> In the deep bosom of the ocean buried.</p>
-			</blockquote>
-		</gapMatchInteraction>
-	</itemBody>
-	<responseProcessing
-		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="gapMatch" title="Richard III (Take 1)" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
+        <correctResponse>
+            <value>W G1</value>
+            <value>Su G2</value>
+        </correctResponse>
+        <mapping defaultValue="-1" lowerBound="0">
+            <mapEntry mapKey="W G1" mappedValue="1"/>
+            <mapEntry mapKey="Su G2" mappedValue="2"/>
+        </mapping>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <gapMatchInteraction responseIdentifier="RESPONSE" shuffle="false">
+            <prompt>Identify the missing words in this famous quote from Shakespeare's Richard III.</prompt>
+            <gapText identifier="W" matchMax="1">winter</gapText>
+            <gapText identifier="Sp" matchMax="1">spring</gapText>
+            <gapText identifier="Su" matchMax="1">summer</gapText>
+            <gapText identifier="A" matchMax="1">autumn</gapText>
+            <blockquote>
+                <p>Now is the <gap identifier="G1"/> of our discontent<br/> Made glorious <gap
+                        identifier="G2"/> by this sun of York;<br/> And all the clouds that lour'd
+                    upon our house<br/> In the deep bosom of the ocean buried.</p>
+            </blockquote>
+        </gapMatchInteraction>
+    </itemBody>
+    <responseProcessing
+        template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
 </assessmentItem>

--- a/app/src/test/resources/qti/gap_match_multiple_responses.xml
+++ b/app/src/test/resources/qti/gap_match_multiple_responses.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
-	identifier="gapMatch" title="Richard III (Take 1)" adaptive="false" timeDependent="false">
-	<responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
-		<correctResponse>
-			<value>W G1</value>
-			<value>Su G2</value>
-		</correctResponse>
-		<mapping defaultValue="-1" lowerBound="0">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="gapMatch" title="Richard III (Take 1)" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
+        <correctResponse>
+            <value>W G1</value>
+            <value>Su G2</value>
+        </correctResponse>
+        <mapping defaultValue="-1" lowerBound="0">
             <mapEntry mapKey="W G2" mappedValue="4"/>
             <mapEntry mapKey="W G1" mappedValue="1"/>
             <mapEntry mapKey="Su G2" mappedValue="2"/>
             <mapEntry mapKey="Su G1" mappedValue="3"/>
             <mapEntry mapKey="Sp G1" mappedValue="5"/>
-		</mapping>
-	</responseDeclaration>
-	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
-	<itemBody>
-		<gapMatchInteraction responseIdentifier="RESPONSE" shuffle="false">
-			<prompt>Identify the missing words in this famous quote from Shakespeare's Richard III.</prompt>
-			<gapText identifier="W" matchMax="2">winter</gapText>
-			<gapText identifier="Sp" matchMax="1">spring</gapText>
-			<gapText identifier="Su" matchMax="2">summer</gapText>
-			<gapText identifier="A" matchMax="1">autumn</gapText>
-			<blockquote>
-				<p>Now is the <gap identifier="G1"/> of our discontent<br/> Made glorious <gap
-						identifier="G2"/> by this sun of York;<br/> And all the clouds that lour'd
-					upon our house<br/> In the deep bosom of the ocean buried.</p>
-			</blockquote>
-		</gapMatchInteraction>
-	</itemBody>
-	<responseProcessing
-		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
+        </mapping>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <gapMatchInteraction responseIdentifier="RESPONSE" shuffle="false">
+            <prompt>Identify the missing words in this famous quote from Shakespeare's Richard III.</prompt>
+            <gapText identifier="W" matchMax="2">winter</gapText>
+            <gapText identifier="Sp" matchMax="1">spring</gapText>
+            <gapText identifier="Su" matchMax="2">summer</gapText>
+            <gapText identifier="A" matchMax="1">autumn</gapText>
+            <blockquote>
+                <p>Now is the <gap identifier="G1"/> of our discontent<br/> Made glorious <gap
+                        identifier="G2"/> by this sun of York;<br/> And all the clouds that lour'd
+                    upon our house<br/> In the deep bosom of the ocean buried.</p>
+            </blockquote>
+        </gapMatchInteraction>
+    </itemBody>
+    <responseProcessing
+        template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
 </assessmentItem>

--- a/app/src/test/resources/qti/inline_choice_custom_processing.xml
+++ b/app/src/test/resources/qti/inline_choice_custom_processing.xml
@@ -21,6 +21,17 @@
                 In the deep bosom of the ocean buried.</p>
         </blockquote>
     </itemBody>
-    <responseProcessing
-        template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+    <responseProcessing>
+        <responseCondition>
+            <responseIf>
+                <match>
+                    <variable identifier="RESPONSE"/>
+                    <baseValue baseType="identifier">Y</baseValue>
+                </match>
+                <setOutcomeValue identifier="SCORE">
+                    <baseValue baseType="float">1</baseValue>
+                </setOutcomeValue>
+            </responseIf>
+        </responseCondition>
+    </responseProcessing>
 </assessmentItem>

--- a/app/src/test/resources/qti/inline_choice_multiple_choices.xml
+++ b/app/src/test/resources/qti/inline_choice_multiple_choices.xml
@@ -3,17 +3,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
     identifier="inlineChoice" title="Richard III (Take 2)" adaptive="false" timeDependent="false">
-    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+    <responseDeclaration identifier="RESPONSE_1" cardinality="single" baseType="identifier">
         <correctResponse>
             <value>Y</value>
         </correctResponse>
     </responseDeclaration>
+    <responseDeclaration identifier="RESPONSE_2" cardinality="single" baseType="identifier">
+    <correctResponse>
+        <value>N</value>
+    </correctResponse>
+</responseDeclaration>
     <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
     <itemBody>
         <p>Identify the missing word in this famous quote from Shakespeare's Richard III.</p>
         <blockquote>
-            <p>Now is the winter of our discontent<br/> Made glorious summer by this sun of
-                    <inlineChoiceInteraction responseIdentifier="RESPONSE" shuffle="false">
+            <p><inlineChoiceInteraction responseIdentifier="RESPONSE_2" shuffle="false">
+                <inlineChoice identifier="N">Now</inlineChoice>
+                <inlineChoice identifier="T">Then</inlineChoice>
+            </inlineChoiceInteraction> is the winter of our discontent<br/> Made glorious summer by this sun of
+                    <inlineChoiceInteraction responseIdentifier="RESPONSE_1" shuffle="true">
                     <inlineChoice identifier="G">Gloucester</inlineChoice>
                     <inlineChoice identifier="L">Lancaster</inlineChoice>
                     <inlineChoice identifier="Y">York</inlineChoice>

--- a/app/src/test/resources/qti/match.xml
+++ b/app/src/test/resources/qti/match.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
-	identifier="match" title="Characters and Plays" adaptive="false" timeDependent="false">
-	<responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
-		<correctResponse>
-			<value>C R</value>
-			<value>D M</value>
-			<value>L M</value>
-			<value>P T</value>
-		</correctResponse>
-		<mapping defaultValue="0">
-			<mapEntry mapKey="C R" mappedValue="1"/>
-			<mapEntry mapKey="D M" mappedValue="0.5"/>
-			<mapEntry mapKey="L M" mappedValue="0.5"/>
-			<mapEntry mapKey="P T" mappedValue="1"/>
-		</mapping>
-	</responseDeclaration>
-	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
-	<itemBody>
-		<matchInteraction responseIdentifier="RESPONSE" shuffle="true" maxAssociations="4">
-			<prompt>Match the following characters to the Shakespeare play they appeared in:</prompt>
-			<simpleMatchSet>
-				<simpleAssociableChoice identifier="C" matchMax="1">Capulet</simpleAssociableChoice>
-				<simpleAssociableChoice identifier="D" matchMax="1">Demetrius</simpleAssociableChoice>
-				<simpleAssociableChoice identifier="L" matchMax="1">Lysander</simpleAssociableChoice>
-				<simpleAssociableChoice identifier="P" matchMax="1">Prospero</simpleAssociableChoice>
-			</simpleMatchSet>
-			<simpleMatchSet>
-				<simpleAssociableChoice identifier="M" matchMax="4">A Midsummer-Night's Dream</simpleAssociableChoice>
-				<simpleAssociableChoice identifier="R" matchMax="4">Romeo and Juliet</simpleAssociableChoice>
-				<simpleAssociableChoice identifier="T" matchMax="4">The Tempest</simpleAssociableChoice>
-			</simpleMatchSet>
-		</matchInteraction>
-	</itemBody>
-	<responseProcessing
-		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="match" title="Characters and Plays" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="directedPair">
+        <correctResponse>
+            <value>C R</value>
+            <value>D M</value>
+            <value>L M</value>
+            <value>P T</value>
+        </correctResponse>
+        <mapping defaultValue="0">
+            <mapEntry mapKey="C R" mappedValue="1"/>
+            <mapEntry mapKey="D M" mappedValue="0.5"/>
+            <mapEntry mapKey="L M" mappedValue="0.5"/>
+            <mapEntry mapKey="P T" mappedValue="1"/>
+        </mapping>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <matchInteraction responseIdentifier="RESPONSE" shuffle="true" maxAssociations="4">
+            <prompt>Match the following characters to the Shakespeare play they appeared in:</prompt>
+            <simpleMatchSet>
+                <simpleAssociableChoice identifier="C" matchMax="1">Capulet</simpleAssociableChoice>
+                <simpleAssociableChoice identifier="D" matchMax="1">Demetrius</simpleAssociableChoice>
+                <simpleAssociableChoice identifier="L" matchMax="1">Lysander</simpleAssociableChoice>
+                <simpleAssociableChoice identifier="P" matchMax="1">Prospero</simpleAssociableChoice>
+            </simpleMatchSet>
+            <simpleMatchSet>
+                <simpleAssociableChoice identifier="M" matchMax="4">A Midsummer-Night's Dream</simpleAssociableChoice>
+                <simpleAssociableChoice identifier="R" matchMax="4">Romeo and Juliet</simpleAssociableChoice>
+                <simpleAssociableChoice identifier="T" matchMax="4">The Tempest</simpleAssociableChoice>
+            </simpleMatchSet>
+        </matchInteraction>
+    </itemBody>
+    <responseProcessing
+        template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
 </assessmentItem>

--- a/app/src/test/resources/qti/text_entry.xml
+++ b/app/src/test/resources/qti/text_entry.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
-	identifier="textEntry" title="Richard III (Take 3)" adaptive="false" timeDependent="false">
-	<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="string">
-		<correctResponse>
-			<value>York</value>
-		</correctResponse>
-		<mapping defaultValue="0">
-			<mapEntry mapKey="York" mappedValue="1"/>
-			<mapEntry mapKey="york" mappedValue="0.5"/>
-		</mapping>
-	</responseDeclaration>
-	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
-	<itemBody>
-		<p>Identify the missing word in this famous quote from Shakespeare's Richard III.</p>
-		<blockquote>
-			<p>Now is the winter of our discontent<br/> Made glorious summer by this sun of
-					<textEntryInteraction responseIdentifier="RESPONSE" expectedLength="15"/>;<br/>
-				And all the clouds that lour'd upon our house<br/> In the deep bosom of the ocean
-				buried.</p>
-		</blockquote>
-	</itemBody>
-	<responseProcessing
-		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+    identifier="textEntry" title="Richard III (Take 3)" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="string">
+        <correctResponse>
+            <value>York</value>
+        </correctResponse>
+        <mapping defaultValue="0">
+            <mapEntry mapKey="York" mappedValue="1"/>
+            <mapEntry mapKey="york" mappedValue="0.5"/>
+        </mapping>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <p>Identify the missing word in this famous quote from Shakespeare's Richard III.</p>
+        <blockquote>
+            <p>Now is the winter of our discontent<br/> Made glorious summer by this sun of
+                    <textEntryInteraction responseIdentifier="RESPONSE" expectedLength="15"/>;<br/>
+                And all the clouds that lour'd upon our house<br/> In the deep bosom of the ocean
+                buried.</p>
+        </blockquote>
+    </itemBody>
+    <responseProcessing
+        template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/map_response"/>
 </assessmentItem>


### PR DESCRIPTION
Add initial support for converting inline choice question types to the Learnosity format.

Other changes:
- Update the app version to 0.1.0 to indicate the first released usable version
- Replace tabs with spaces in all example QTI files
- Delete unused TextEntryInteraction.java
- Rename the utility class for clarity

Refs: #12