### PR TITLE
fix: make tests OS agnostic

### DIFF
--- a/app/src/main/java/com/epam/learnosity/converter/qti/core/extractor/file/FileSourceSupplier.java
+++ b/app/src/main/java/com/epam/learnosity/converter/qti/core/extractor/file/FileSourceSupplier.java
@@ -45,7 +45,7 @@ public class FileSourceSupplier implements SourceSupplier {
             List<Path> list = stream.filter(file -> file.toString().endsWith(".xml")).toList();
             return list.stream().map(file -> {
                     try {
-                        String content = new String(Files.readAllBytes(file));
+                        String content = Files.readString(file);
                         return new Resource(file.getFileName().toString(), content);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/AssessmentItemReaderTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/AssessmentItemReaderTest.groovy
@@ -221,11 +221,12 @@ class AssessmentItemReaderTest extends Specification {
         validResponses[1].getMappedValue() == "0.5"
 
         def itemBody = result.getItemBody()
-        itemBody.getContentAsSingleString() == "<p>Identify the missing word in this famous quote from Shakespeare's" +
-                " Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by " +
-                "this sun of\n                    <textEntryInteraction responseIdentifier=\"RESPONSE\" " +
-                "expectedLength=\"15\"/>;<br/>\n                And all the clouds that lour'd upon our house<br/>" +
-                " In the deep bosom of the ocean\n                buried.</p>\n        </blockquote>"
+        itemBody.getContentAsSingleString().replace("\r\n", "\n") == "<p>Identify the missing word in this famous " +
+                "quote from Shakespeare's Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> " +
+                "Made glorious summer by this sun of\n                    <textEntryInteraction " +
+                "responseIdentifier=\"RESPONSE\" expectedLength=\"15\"/>;<br/>\n                And all the clouds" +
+                " that lour'd upon our house<br/> In the deep bosom of the ocean\n                buried.</p>\n   " +
+                "     </blockquote>"
     }
 
     def readMultipleTextEntryTest() {
@@ -275,16 +276,13 @@ class AssessmentItemReaderTest extends Specification {
         responseDeclarations[1].getMapping().getMapEntry()[1].getMappedValue() == "4"
 
         def itemBody = result.getItemBody()
-        itemBody.getContentAsSingleString() == "<div xmlns=\"http://www.imsglobal.org/xsd/imsqti_v2p1\" " +
-                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">Level 1 CH1 Géoculture\n" +
+        itemBody.getContentAsSingleString().replace("\r\n", "\n") == "<div xmlns=\"http://www.imsglobal.org/xsd/" +
+                "imsqti_v2p1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">Level 1 CH1 Géoculture\n" +
                 "            <br/><strong>A</strong>Match each letter in the map of the Paris region with the name " +
-                "of the place it represents.\n" +
-                "            (10 points)\n" +
-                "            <br/><img src=\"L1_CH01101.gif\" alt=\"\"/><br/>\n" +
-                "            le jardin de Giverny\n" +
-                "            <br/><textEntryInteraction responseIdentifier=\"RESPONSE_1\" expectedLength=\"6\"/>\n" +
-                "        </div><p><textEntryInteraction responseIdentifier=\"RESPONSE_2\" expectedLength=\"6\"/>\n" +
-                "        </p>"
+                "of the place it represents.\n            (10 points)\n            <br/><img src=\"L1_CH01101.gif\"" +
+                " alt=\"\"/><br/>\n            le jardin de Giverny\n            <br/><textEntryInteraction " +
+                "responseIdentifier=\"RESPONSE_1\" expectedLength=\"6\"/>\n        </div><p><textEntryInteraction" +
+                " responseIdentifier=\"RESPONSE_2\" expectedLength=\"6\"/>\n        </p>"
     }
 
     def readSimpleAssociationTest() {
@@ -450,10 +448,10 @@ class AssessmentItemReaderTest extends Specification {
         interaction.getType() == QtiType.GAP_MATCH
         interaction.getResponseIdentifier() == "RESPONSE"
         interaction.getPrompt() == "Identify the missing words in this famous quote from Shakespeare's Richard III."
-        interaction.getTextBlock() == "<blockquote><p>Now is the <gap identifier=\"G1\"/> of our discontent<br/> " +
-                "Made glorious <gap identifier=\"G2\"/> by this sun of York;<br/> And all the clouds that lour'd\n" +
-                "                    upon our house<br/> In the deep bosom of the ocean buried.</p>\n            " +
-                "</blockquote>"
+        interaction.getTextBlock().replace("\r\n", "\n") == "<blockquote><p>Now is the <gap identifier=\"G1\"/> of " +
+                "our discontent<br/> Made glorious <gap identifier=\"G2\"/> by this sun of York;<br/> And all the" +
+                " clouds that lour'd\n                    upon our house<br/> In the deep bosom of the ocean " +
+                "buried.</p>\n            </blockquote>"
         !interaction.isShuffle()
 
         def choices = interaction.getGapText()
@@ -498,13 +496,14 @@ class AssessmentItemReaderTest extends Specification {
         validResponses[0] == "Y"
 
         def itemBody = result.getItemBody()
-        itemBody.getContentAsSingleString() == "<p>Identify the missing word in this famous quote from Shakespeare's" +
-                " Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by" +
-                " this sun of\n                    <inlineChoiceInteraction responseIdentifier=\"RESPONSE\" " +
-                "shuffle=\"false\"><inlineChoice identifier=\"G\">Gloucester</inlineChoice><inlineChoice " +
-                "identifier=\"L\">Lancaster</inlineChoice><inlineChoice identifier=\"Y\">York</inlineChoice>\n" +
-                "                </inlineChoiceInteraction>;<br/> And all the clouds that lour'd upon our house" +
-                "<br/>\n                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
+        itemBody.getContentAsSingleString().replace("\r\n", "\n") == "<p>Identify the missing word in this famous" +
+                " quote from Shakespeare's Richard III.</p><blockquote><p>Now is the winter of our discontent<br/>" +
+                " Made glorious summer by this sun of\n                    <inlineChoiceInteraction " +
+                "responseIdentifier=\"RESPONSE\" shuffle=\"false\"><inlineChoice identifier=\"G\">Gloucester" +
+                "</inlineChoice><inlineChoice identifier=\"L\">Lancaster</inlineChoice><inlineChoice " +
+                "identifier=\"Y\">York</inlineChoice>\n                </inlineChoiceInteraction>;<br/> And all the" +
+                " clouds that lour'd upon our house<br/>\n                In the deep bosom of the ocean buried.</p>" +
+                "\n        </blockquote>"
     }
 
     def readUploadTest() {
@@ -533,9 +532,9 @@ class AssessmentItemReaderTest extends Specification {
 
         def itemBody = result.getItemBody()
         itemBody.getContent().size() == 1
-        itemBody.getContent().getFirst() == "<p>A chocolate factory produces several types of chocolate, some of" +
-                " which have nut centres.\n            The chocolates are mixed together and are randomly packed " +
-                "into cartons of ten.</p>"
+        itemBody.getContentAsSingleString().replace("\r\n", "\n") == "<p>A chocolate factory produces several types" +
+                " of chocolate, some of which have nut centres.\n            The chocolates are mixed together and" +
+                " are randomly packed into cartons of ten.</p>"
 
         UploadInteraction interaction = itemBody.getInteraction() as UploadInteraction
         interaction.getType() == QtiType.UPLOAD

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/gapmatch/GapMatchConverterTest.groovy
@@ -45,9 +45,10 @@ class GapMatchConverterTest extends Specification {
         !clozeAssociation.isInstantFeedback()
         !clozeAssociation.isShuffleOptions()
         !clozeAssociation.isDuplicateResponses()
-        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made " +
-                "glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n             " +
-                "       upon our house<br/> In the deep bosom of the ocean buried.</p>\n            </blockquote>"
+        clozeAssociation.getTemplate().replace("\r\n", "\n") == "<blockquote><p>Now is the {{response}} of our " +
+                "discontent<br/> Made glorious {{response}} by this sun of York;<br/> And all the clouds that" +
+                " lour'd\n                    upon our house<br/> In the deep bosom of the ocean buried.</p>\n " +
+                "           </blockquote>"
 
         def possibleResponses = clozeAssociation.getPossibleResponses()
         possibleResponses.size() == 4
@@ -87,9 +88,10 @@ class GapMatchConverterTest extends Specification {
         !clozeAssociation.isInstantFeedback()
         !clozeAssociation.isShuffleOptions()
         clozeAssociation.isDuplicateResponses()
-        clozeAssociation.getTemplate() == "<blockquote><p>Now is the {{response}} of our discontent<br/> Made " +
-                "glorious {{response}} by this sun of York;<br/> And all the clouds that lour'd\n             " +
-                "       upon our house<br/> In the deep bosom of the ocean buried.</p>\n            </blockquote>"
+        clozeAssociation.getTemplate().replace("\r\n", "\n") == "<blockquote><p>Now is the {{response}} of our" +
+                " discontent<br/> Made glorious {{response}} by this sun of York;<br/> And all the clouds that" +
+                " lour'd\n                    upon our house<br/> In the deep bosom of the ocean buried.</p>\n" +
+                "            </blockquote>"
 
         def possibleResponses = clozeAssociation.getPossibleResponses()
         possibleResponses.size() == 4

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/inlinechoice/InlineChoiceConverterTest.groovy
@@ -43,10 +43,10 @@ class InlineChoiceConverterTest extends Specification {
         clozeDropdown.getFeedbackAttempts() == 0
         !clozeDropdown.instantFeedback
         !clozeDropdown.isShuffleOptions()
-        clozeDropdown.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's Richard" +
-                " III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by this sun" +
-                " of\n                    {{response}};<br/> And all the clouds that lour'd upon our house<br/>\n" +
-                "                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
+        clozeDropdown.getTemplate().replace("\r\n", "\n") == "<p>Identify the missing word in this famous quote from" +
+                " Shakespeare's Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious" +
+                " summer by this sun of\n                    {{response}};<br/> And all the clouds that lour'd upon" +
+                " our house<br/>\n                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
 
         def possibleResponses = clozeDropdown.getPossibleResponses()
         possibleResponses.size() == 1
@@ -88,10 +88,11 @@ class InlineChoiceConverterTest extends Specification {
         clozeDropdown.getFeedbackAttempts() == 0
         !clozeDropdown.instantFeedback
         clozeDropdown.isShuffleOptions()
-        clozeDropdown.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's " +
-                "Richard III.</p><blockquote><p>{{response}} is the winter of our discontent<br/> Made glorious" +
-                " summer by this sun of\n                    {{response}};<br/> And all the clouds that lour'd upon" +
-                " our house<br/>\n                In the deep bosom of the ocean buried.</p>\n        </blockquote>"
+        clozeDropdown.getTemplate().replace("\r\n", "\n") == "<p>Identify the missing word in this famous quote from" +
+                " Shakespeare's Richard III.</p><blockquote><p>{{response}} is the winter of our discontent<br/> " +
+                "Made glorious summer by this sun of\n                    {{response}};<br/> And all the clouds that" +
+                " lour'd upon our house<br/>\n                In the deep bosom of the ocean buried.</p>\n        " +
+                "</blockquote>"
 
         def possibleResponses = clozeDropdown.getPossibleResponses()
         possibleResponses.size() == 2

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/textentry/TextEntryConverterTest.groovy
@@ -44,10 +44,11 @@ class TextEntryConverterTest extends Specification {
         !clozeText.isInstantFeedback()
         !clozeText.isShuffleOptions()
         !clozeText.isCaseSensitive()
-        clozeText.getTemplate() == "<p>Identify the missing word in this famous quote from Shakespeare's Richard " +
-                "III.</p><blockquote><p>Now is the winter of our discontent<br/> Made glorious summer by this sun" +
-                " of\n                    {{response}};<br/>\n                And all the clouds that lour'd upon" +
-                " our house<br/> In the deep bosom of the ocean\n                buried.</p>\n        </blockquote>"
+        clozeText.getTemplate().replace("\r\n", "\n") == "<p>Identify the missing word in this famous quote from" +
+                " Shakespeare's Richard III.</p><blockquote><p>Now is the winter of our discontent<br/> Made " +
+                "glorious summer by this sun of\n                    {{response}};<br/>\n                And all the" +
+                " clouds that lour'd upon our house<br/> In the deep bosom of the ocean\n                buried." +
+                "</p>\n        </blockquote>"
 
         def validation = clozeText.getValidation()
         validation.getScoringType() == Validation.ScoringType.EXACT_MATCH
@@ -84,7 +85,7 @@ class TextEntryConverterTest extends Specification {
         !clozeText.isInstantFeedback()
         !clozeText.isShuffleOptions()
         clozeText.isCaseSensitive()
-        clozeText.getTemplate() == "<div xmlns=\"http://www.imsglobal.org/xsd/imsqti_v2p1\" " +
+        clozeText.getTemplate().replace("\r\n", "\n") == "<div xmlns=\"http://www.imsglobal.org/xsd/imsqti_v2p1\" " +
                 "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">Level 1 CH1 Géoculture\n" +
                 "            <br/><strong>A</strong>Match each letter in the map of the Paris region with the name " +
                 "of the place it represents.\n" +

--- a/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/upload/UploadConverterTest.groovy
+++ b/app/src/test/groovy/com/epam/learnosity/converter/qti/core/converter/qti2p1/upload/UploadConverterTest.groovy
@@ -35,11 +35,12 @@ class UploadConverterTest extends Specification {
         then:
         fileUpload.getType() == "fileupload"
         fileUpload.getMetadata() == null
-        fileUpload.getStimulus() == "<p>A chocolate factory produces several types of chocolate, some of which have nut centres.\n" +
-                "            The chocolates are mixed together and are randomly packed into cartons of ten.</p><p>Build a spreadsheet to simulate 50 cartons of chocolates when each carton\n" +
-                "                contains 10 chocolates, and when one-seventh of the chocolates have nut centres.\n" +
-                "                Your spreadsheet should include 50 rows representing the 50 cartons, each row\n" +
-                "                containing 10 columns to represent the chocolates.</p>"
+        fileUpload.getStimulus().replace("\r\n", "\n") == "<p>A chocolate factory produces several types of" +
+                " chocolate, some of which have nut centres.\n            The chocolates are mixed together and are" +
+                " randomly packed into cartons of ten.</p><p>Build a spreadsheet to simulate 50 cartons of chocolates" +
+                " when each carton\n                contains 10 chocolates, and when one-seventh of the chocolates" +
+                " have nut centres.\n                Your spreadsheet should include 50 rows representing the 50" +
+                " cartons, each row\n                containing 10 columns to represent the chocolates.</p>"
         fileUpload.allowPdf
         fileUpload.allowJpg
         fileUpload.allowPng


### PR DESCRIPTION
Some tests fail due to CRLF being used on Windows. Make tests OS agnostic by converting CRLF to LF for comparison in tests.

Other changes:
- Use a new approach to reading file contents in FileSourceSupplier

Refs: #16